### PR TITLE
Feature/rec endpoint - Remove :id param

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -28,7 +28,7 @@ router.get("/:id/history", (req, res, next) => {
     .catch(err => next(err));
 });
 
-router.get("/:id/recommendations", jwtAuth, (req, res, next) => {
+router.get("/recommendations", jwtAuth, (req, res, next) => {
   let topChoices;
   let sortedSimilarGames;
 

--- a/server/test/users.test.js
+++ b/server/test/users.test.js
@@ -80,11 +80,11 @@ describe("ASYNC Capstone API - Users", () => {
     });
   });
 
-  describe("GET /api/users/:id/recommendations", () => {
+  describe("GET /api/users/recommendations", () => {
     it("should return the correct number of recommendations", () => {
       return chai
         .request(app)
-        .get(`/api/users/${user.id}/recommendations`)
+        .get(`/api/users/recommendations`)
         .set("Authorization", `Bearer ${token}`)
         .then(res => {
           expect(res).to.have.status(200);
@@ -96,7 +96,7 @@ describe("ASYNC Capstone API - Users", () => {
     it("should return recommendations with the correct fields", () => {
       return chai
         .request(app)
-        .get(`/api/users/${user.id}/recommendations`)
+        .get(`/api/users/recommendations`)
         .set("Authorization", `Bearer ${token}`)
         .then(res => {
           expect(res.body).to.be.an("array");


### PR DESCRIPTION
I screwed up and put an unnecessary ID param in the endpoint path. The endpoint should just be GET /api/users/recommendations.