### PR TITLE
Feature/battle filters - Filter out new and unreleased games

### DIFF
--- a/server/db/data.js
+++ b/server/db/data.js
@@ -37,6 +37,7 @@ const games = [
   {
     name: "Super Mario 64",
     _id: "5c9a959ba5d0dd09e07f45a7",
+    firstReleaseDate: 835488000,
     igdb: {
       id: 1074,
       slug: "super-mario-64"
@@ -90,6 +91,7 @@ const games = [
   {
     name: "The Legend of Zelda",
     _id: "5c9a959ba5d0dd09e07f45a8",
+    firstReleaseDate: 509328000,
     igdb: {
       id: 1022,
       slug: "the-legend-of-zelda"
@@ -112,6 +114,7 @@ const games = [
   {
     name: "Mortal Kombat",
     _id: "5c9a959ba5d0dd09e07f45a9",
+    firstReleaseDate: 712713600,
     igdb: {
       id: 1618,
       slug: "mortal-kombat--2"
@@ -122,6 +125,7 @@ const games = [
   {
     name: "Street Fighter II",
     _id: "5c9a959ba5d0dd09e07f45a0",
+    firstReleaseDate: 665798400,
     igdb: {
       id: 3186,
       slug: "street-fighter-ii"
@@ -143,6 +147,7 @@ const games = [
   {
     name: "Halo: Combat Evolved",
     _id: "5c9a959ba5d0dd09e07f45a1",
+    firstReleaseDate: 1005782400,
     igdb: {
       id: 740,
       slug: "halo-combat-evolved"
@@ -154,6 +159,7 @@ const games = [
   {
     name: "Superman",
     _id: "5c9a959ba5d0dd09e07f45a2",
+    firstReleaseDate: 928108800,
     igdb: {
       id: 3005,
       slug: "superman"
@@ -165,6 +171,7 @@ const games = [
   {
     name: "Final Fantasy VII",
     _id: "5c9a959ba5d0dd09e07f45a3",
+    firstReleaseDate: 854668800,
     igdb: {
       id: 427,
       slug: "final-fantasy-vii"
@@ -176,6 +183,7 @@ const games = [
   {
     name: "WWF No Mercy",
     _id: "5c9a959ba5d0dd09e07f45a4",
+    firstReleaseDate: 974419200,
     igdb: {
       id: 3644,
       slug: "wwf-no-mercy"
@@ -189,6 +197,7 @@ const games = [
   {
     name: "Super Smash Bros.",
     _id: "5c9a959ba5d0dd09e07f45a5",
+    firstReleaseDate: 916876800,
     igdb: {
       id: 1626,
       slug: "super-smash-bros"
@@ -212,6 +221,7 @@ const games = [
   {
     name: "Candy Crush Saga",
     _id: "5c9a959ba5d0dd09e07f45a6",
+    firstReleaseDate: 1334188800,
     igdb: {
       id: 5636,
       slug: "candy-crush-saga"
@@ -232,12 +242,13 @@ const games = [
       "https://images.igdb.com/igdb/image/upload/t_720p/u9s7ap9gi5kestfxhxdf.jpg"
   },
   {
+    name: "God of War II",
     igdb: {
       id: 551,
       slug: "god-of-war-ii"
     },
     similar_games: [112, 127, 136, 499, 549, 550, 552, 1029, 1128, 3644],
-    name: "God of War II",
+    firstReleaseDate: 1173744000,
     coverUrl:
       "https://images.igdb.com/igdb/image/upload/t_720p/f3mwxy3opbrbmcyguhly.jpg",
     createdAt: "2019-03-27T22:42:41.704Z",
@@ -277,6 +288,7 @@ const games = [
   },
   {
     name: "Super Mario Bros. 3",
+    firstReleaseDate: 591840000,
     coverUrl:
       "https://images.igdb.com/igdb/image/upload/t_720p/u9s7ap9gi5kestfxhxdf.jpg",
     igdb: {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2026,6 +2026,7 @@
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2042,6 +2043,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2201,7 +2203,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2293,7 +2296,8 @@
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3436,6 +3440,11 @@
           }
         }
       }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "mongodb": {
       "version": "3.1.13",

--- a/server/package.json
+++ b/server/package.json
@@ -26,6 +26,7 @@
     "express": "^4.16.4",
     "jsonwebtoken": "^8.5.0",
     "knex": "^0.16.3",
+    "moment": "^2.24.0",
     "mongoose": "^5.4.19",
     "morgan": "^1.9.1",
     "nodemon": "^1.18.10",

--- a/server/test/games.test.js
+++ b/server/test/games.test.js
@@ -209,7 +209,8 @@ describe("ASYNC Capstone API - Games", () => {
               "igdb",
               "platforms",
               "summary",
-              "similar_games"
+              "similar_games",
+              "firstReleaseDate"
             );
             expect(game.igdb).to.have.keys("id", "slug");
           });

--- a/server/utils/queries.js
+++ b/server/utils/queries.js
@@ -1,5 +1,4 @@
 const History = require("../models/history");
-const Game = require("../models/game");
 
 const totalGamesPlayed = id =>
   History.find({
@@ -12,25 +11,14 @@ const gamesWon = async id => {
   return played.length;
 };
 
-// const gameName = async id => {
-//   const name = await History.find({ choice: id }).populate("choice");
-//   console.log(name);
-//   if (name.length < 1) {
+// const gamePic = async id => {
+//   const picture = await History.find({ choice: id }).populate("choice");
+//   if (picture.length < 1) {
 //     // Game has never been chosen...pull cover art from games
-//     const noChoiceName = await Game.find({ _id: id });
-//     return noChoiceName[0].name;
+//     const noChoicePic = await Game.find({ _id: id });
+//     return noChoicePic[0].coverUrl;
 //   }
-//   return name[0].choice.name;
+//   return picture[0].choice.coverUrl;
 // };
 
-const gamePic = async id => {
-  const picture = await History.find({ choice: id }).populate("choice");
-  if (picture.length < 1) {
-    // Game has never been chosen...pull cover art from games
-    const noChoicePic = await Game.find({ _id: id });
-    return noChoicePic[0].coverUrl;
-  }
-  return picture[0].choice.coverUrl;
-};
-
-module.exports = { totalGamesPlayed, gamesWon, gamePic };
+module.exports = { totalGamesPlayed, gamesWon };


### PR DESCRIPTION
Adds a filter to GET /api/games/battle that weeds out all games that either have not been released or were released within the last six months. If a games doesn't currently have a firstReleaseDate property in our database, it will be filtered out. I'm working through Mongo now to refresh all the games currently in our database.