### PR TITLE
Bug/expanding jwts - Remove history from user response object

### DIFF
--- a/server/db/data.js
+++ b/server/db/data.js
@@ -460,6 +460,13 @@ const histories = [
     gameOne: "5c9a959ba5d0dd09e07f45a3",
     gameTwo: "5c9a959ba5d0dd09e07f45a1",
     choice: "5c9a959ba5d0dd09e07f45a3"
+  },
+  {
+    _id: "222222222222222222222217",
+    userId: "333333333333333333333300",
+    gameOne: "5c9a959ba5d0dd09e07f45a2",
+    gameTwo: "5c9a959ba5d0dd09e07f45a1",
+    choice: "5c9a959ba5d0dd09e07f45a2"
   }
 ];
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -19,6 +19,7 @@ userSchema.set("toJSON", {
     delete result._id;
     delete result.__v;
     delete result.password;
+    delete result.history;
   }
 });
 

--- a/server/test/users.test.js
+++ b/server/test/users.test.js
@@ -65,7 +65,6 @@ describe("ASYNC Capstone API - Users", () => {
             "username",
             "firstName",
             "lastName",
-            "history",
             "admin",
             "battles"
           );

--- a/server/test/users.test.js
+++ b/server/test/users.test.js
@@ -113,6 +113,19 @@ describe("ASYNC Capstone API - Users", () => {
     });
   });
 
+  describe("GET /api/users/:id/topHistory", () => {
+    it("should return the correct number of games", function() {
+      return chai
+        .request(app)
+        .get(`/api/users/${user.id}/topHistory`)
+        .then(res => {
+          expect(res).to.have.status(200);
+          expect(res.body).to.be.an("array");
+          expect(res.body.length).to.equal(6);
+        });
+    });
+  });
+
   describe("GET /api/users/recommendations", () => {
     it("should return recommendations with the correct fields", () => {
       return chai


### PR DESCRIPTION
Removes the history array from the User model when returned as JSON. This stops the JSON web token from expanding as the user's history grows.