### PR TITLE
Bug/restrict auth token - Restrict authToken payload

### DIFF
--- a/server/db/data.js
+++ b/server/db/data.js
@@ -585,6 +585,67 @@ const games = [
       "https://res.cloudinary.com/hjihgo1pd/image/upload/v1554169070/5c9bfb5d054d8f2e1010f118.jpg",
     firstReleaseDate: 1280188800,
     id: "5c9bfb5d054d8f2e1010f118"
+  },
+  {
+    igdb: {
+      id: 1511,
+      slug: "pokemon-blue"
+    },
+    similar_games: [
+      427,
+      1512,
+      1514,
+      1517,
+      1558,
+      2286,
+      2287,
+      3222,
+      22387,
+      55092
+    ],
+    motivations: ["achievement"],
+    subMotivations: ["completion"],
+    core: true,
+    name: "Pokémon Blue",
+    coverUrl:
+      "https://images.igdb.com/igdb/image/upload/t_720p/dhsdbh50wrvoe6xmzx3i.jpg",
+    summary:
+      "You've finally been granted your Pokémon Trainer's license. Now, it's time to head out to become the world's greatest Pokémon Trainer. It's going to take all you've got to collect 150 Pokémon in this enormous world. Catch and train monsters like the shockingly-cute Pikachu. Face off against Blastoise's torrential water cannons. Stand strong when facing Pidgeot's stormy Gust. Trade with friends and watch your Pokémon evolve. Important—no single Pokémon can win at all. Can you develop the ultimate Pokémon strategy to defeat the eight Gym Leaders and become the greatest Pokémon Master of all time?",
+    genres: [
+      {
+        _id: "5ca811db9cd89ef9c62583b8",
+        id: 12,
+        name: "Role-playing (RPG)"
+      },
+      {
+        _id: "5ca811db9cd89ef9c62583b7",
+        id: 31,
+        name: "Adventure"
+      }
+    ],
+    platforms: [
+      {
+        _id: "5ca811db9cd89ef9c62583bb",
+        id: 33,
+        name: "Game Boy"
+      },
+      {
+        _id: "5ca811db9cd89ef9c62583ba",
+        id: 37,
+        name: "Nintendo 3DS"
+      },
+      {
+        _id: "5ca811db9cd89ef9c62583b9",
+        id: 47,
+        name: "Virtual Console (Nintendo)"
+      }
+    ],
+    firstReleaseDate: 831686400,
+    createdAt: "2019-04-06T02:41:31.484Z",
+    updatedAt: "2019-04-06T02:47:35.191Z",
+    cloudImage:
+      "https://res.cloudinary.com/hjihgo1pd/image/upload/v1554518492/5ca811db9cd89ef9c62583b6.jpg",
+    id: "5ca811db9cd89ef9c62583b6"
   }
 ];
 

--- a/server/db/data.js
+++ b/server/db/data.js
@@ -646,6 +646,56 @@ const games = [
     cloudImage:
       "https://res.cloudinary.com/hjihgo1pd/image/upload/v1554518492/5ca811db9cd89ef9c62583b6.jpg",
     id: "5ca811db9cd89ef9c62583b6"
+  },
+  {
+    igdb: {
+      id: 128,
+      slug: "assassin-s-creed"
+    },
+    similar_games: [113, 127, 537, 1266, 1970, 5606, 7570, 8263, 9243, 19249],
+    motivations: ["achievement"],
+    subMotivations: ["completion"],
+    core: true,
+    name: "Assassin's Creed",
+    coverUrl:
+      "https://images.igdb.com/igdb/image/upload/t_720p/p73nqxuc20nf8upc22lx.jpg",
+    summary:
+      "Assassin’s Creed is the next-gen game developed by Ubisoft Montreal that will redefine the action genre. While other games claim to be next-gen with impressive graphics and physics, Assassin’s Creed merges technology, game design, theme, and emotions into a world where you instigate chaos and become a vulnerable, yet powerful, agent of change.",
+    genres: [
+      {
+        _id: "5ca67b311a96641ab77ed627",
+        id: 8,
+        name: "Platform"
+      },
+      {
+        _id: "5ca67b311a96641ab77ed626",
+        id: 31,
+        name: "Adventure"
+      }
+    ],
+    platforms: [
+      {
+        _id: "5ca67b311a96641ab77ed62a",
+        id: 6,
+        name: "PC (Microsoft Windows)"
+      },
+      {
+        _id: "5ca67b311a96641ab77ed629",
+        id: 9,
+        name: "PlayStation 3"
+      },
+      {
+        _id: "5ca67b311a96641ab77ed628",
+        id: 12,
+        name: "Xbox 360"
+      }
+    ],
+    createdAt: "2019-04-02T21:02:11.015Z",
+    updatedAt: "2019-04-06T02:47:35.191Z",
+    cloudImage:
+      "https://res.cloudinary.com/hjihgo1pd/image/upload/v1554239031/5ca3cdd309691b1d2a883189.jpg",
+    firstReleaseDate: 1194912000,
+    id: "5ca3cdd309691b1d2a883189"
   }
 ];
 

--- a/server/package.json
+++ b/server/package.json
@@ -52,7 +52,7 @@
   },
   "nyc": {
     "exclude": [
-      "utils/recommendations.js"
+      "utils/*.js"
     ]
   }
 }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -10,7 +10,9 @@ const options = { session: false, failWithError: true };
 const localAuth = passport.authenticate("local", options);
 
 function createAuthToken(user) {
-  return jwt.sign({ user }, JWT_SECRET, {
+  const { id, username, admin } = user;
+  const userInfo = { id, username, admin };
+  return jwt.sign({ user: userInfo }, JWT_SECRET, {
     subject: user.username,
     expiresIn: JWT_EXPIRY
   });

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -580,7 +580,7 @@ router.put("/removewishlist", jwtAuth, (req, res, next) => {
 
 router.put("/:id", jwtAuth, isValidId, (req, res, next) => {
   const { id } = req.params;
-  const { neverPlayed, profilePic } = req.body;
+  const { neverPlayed } = req.body;
 
   const toUpdate = {};
   const updateableFields = ["neverPlayed", "profilePic"];
@@ -606,8 +606,6 @@ router.put("/:id", jwtAuth, isValidId, (req, res, next) => {
       return next(err);
     }
   }
-
-  console.log("to update is ", toUpdate);
 
   return User.findOneAndUpdate({ _id: id }, toUpdate, { new: true })
     .then(user => {


### PR DESCRIPTION
Restricts the information contained in the authToken payload to user ID, username, and admin status. This change may break components on the front-end that had been relying on the currentUser to get user information. These will need to be updated to explicitly request user information from the server.