### PR TITLE
Feature/progress bar - Improve onboarding load time

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,5 +42,11 @@
     "not dead",
     "not ie <= 11",
     "not op_mini all"
-  ]
+  ],
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.{js,jsx}",
+      "!src/index.js"
+    ]
+  }
 }

--- a/client/src/actions/gameActions.js
+++ b/client/src/actions/gameActions.js
@@ -61,7 +61,7 @@ export const fetchGames = () => (dispatch, getState) => {
   if (authToken) {
     options.headers = { Authorization: `Bearer ${authToken}` };
   }
-  fetch(`${API_BASE_URL}/games/battle`, options)
+  return fetch(`${API_BASE_URL}/games/battle`, options)
     .then(res => normalizeResponseErrors(res))
     .then(res => res.json())
     .then(data => {
@@ -71,9 +71,6 @@ export const fetchGames = () => (dispatch, getState) => {
       return !data[0].cloudImage || !data[1].cloudImage
         ? fetchImages(gameOneId, gameTwoId, authToken)
         : "No images fetched";
-    })
-    .then(result => {
-      return result;
     })
     .catch(err => fetchFeedbackError(err));
 };

--- a/client/src/actions/onboarding.js
+++ b/client/src/actions/onboarding.js
@@ -1,18 +1,7 @@
-export const NEXT_TEST_REQUEST = "NEXT_TEST_REQUEST";
-export const nextTestRequest = payload => ({
-  type: NEXT_TEST_REQUEST,
-  payload
-});
-
 export const NEXT_TEST_SUCCESS = "NEXT_TEST_SUCCESS";
 export const nextTestSuccess = payload => ({
   type: NEXT_TEST_SUCCESS,
   payload
-});
-
-export const SET_LOADING = "SET_LOADING";
-export const setLoading = () => ({
-  type: SET_LOADING
 });
 
 export const CLEAR_LOADING = "CLEAR_LOADING";

--- a/client/src/actions/onboarding.js
+++ b/client/src/actions/onboarding.js
@@ -21,7 +21,7 @@ export const clearLoading = () => ({
 });
 
 export const UDPATE_VOTE_COUNT = "UPDATE_VOTE_COUNT";
-export const updateVotecount = count => ({
+export const updateVoteCount = count => ({
   type: UDPATE_VOTE_COUNT,
   count
 });

--- a/client/src/actions/onboarding.js
+++ b/client/src/actions/onboarding.js
@@ -1,25 +1,27 @@
 export const NEXT_TEST_REQUEST = "NEXT_TEST_REQUEST";
-
-export const nextTestRequest = (payload) => ({
+export const nextTestRequest = payload => ({
   type: NEXT_TEST_REQUEST,
   payload
-})
+});
 
 export const NEXT_TEST_SUCCESS = "NEXT_TEST_SUCCESS";
-
-export const nextTestSuccess = (payload) => ({
+export const nextTestSuccess = payload => ({
   type: NEXT_TEST_SUCCESS,
   payload
-})
+});
 
 export const SET_LOADING = "SET_LOADING";
-
-export const CLEAR_LOADING = "CLEAR_LOADING";
-
 export const setLoading = () => ({
   type: SET_LOADING
 });
 
+export const CLEAR_LOADING = "CLEAR_LOADING";
 export const clearLoading = () => ({
   type: CLEAR_LOADING
+});
+
+export const UDPATE_VOTE_COUNT = "UPDATE_VOTE_COUNT";
+export const updateVotecount = count => ({
+  type: UDPATE_VOTE_COUNT,
+  count
 });

--- a/client/src/actions/progressBar.js
+++ b/client/src/actions/progressBar.js
@@ -1,0 +1,5 @@
+export const UPDATE_PROGRESS_BAR = "UPDATE_PROGRESS_BAR";
+export const updateProgressBar = loading => ({
+  type: UPDATE_PROGRESS_BAR,
+  loading
+});

--- a/client/src/components/onBoard/landing-page.js
+++ b/client/src/components/onBoard/landing-page.js
@@ -12,9 +12,9 @@ import {
   fetchFeedback,
   handleVote
 } from "../../actions/gameActions";
-import { updateVotecount } from "../../actions/onboarding";
+import { updateVoteCount } from "../../actions/onboarding";
 import { updateProgressBar } from "../../actions/progressBar";
-import { loadVoteCount, checkVoteCount } from "../../local-storage";
+import { checkVoteCount } from "../../local-storage";
 import Loading from "../loading";
 
 export class LandingPage extends React.Component {
@@ -37,7 +37,7 @@ export class LandingPage extends React.Component {
       );
     }
     const voteCount = checkVoteCount();
-    return dispatch(updateVotecount(voteCount));
+    return dispatch(updateVoteCount(voteCount));
   }
 
   handleFetchFeedback(game) {
@@ -55,8 +55,7 @@ export class LandingPage extends React.Component {
         </div>
       );
     } else {
-      const { games, loggedIn, feedback } = this.props;
-      const count = parseInt(loadVoteCount(), 10);
+      const { count, games, loggedIn, feedback } = this.props;
       if (count <= 13 && !loggedIn) {
         content = <ConnectedUserOnboard />;
       } else if (count > 13 && !loggedIn) {
@@ -103,7 +102,7 @@ const mapStateToProps = state => ({
   nonUserVotes: state.games.nonUserVotes,
   motivations: state.user.motivations,
   userId: checkIfUser(state),
-  loading: state.progressBar.loading
+  loading: state.games.loading
 });
 
 export default connect(mapStateToProps)(LandingPage);

--- a/client/src/components/onBoard/landing-page.js
+++ b/client/src/components/onBoard/landing-page.js
@@ -4,34 +4,40 @@ import { connect } from "react-redux";
 import ConnectedBattle from "../votePage/battle";
 import VoteStats from "../votePage/vote-stats";
 import ConnectedUserOnboard from "./userOnboard";
-import "../styles/landing-page.css";
 import ErrorBoundary from "../errorBoundary";
+import "../styles/landing-page.css";
 import "../styles/card.css";
 import {
   fetchGames,
   fetchFeedback,
   handleVote
 } from "../../actions/gameActions";
-import {
-  loadVoteCount,
-  setVoteLocalStorageVariable
-} from "../../local-storage";
+import { updateVotecount } from "../../actions/onboarding";
+import { updateProgressBar } from "../../actions/progressBar";
+import { loadVoteCount, checkVoteCount } from "../../local-storage";
 import Loading from "../loading";
 
 export class LandingPage extends React.Component {
   componentDidMount() {
     const { loggedIn, nonUserVotes, dispatch, userId } = this.props;
 
-    if (loggedIn && nonUserVotes.length) {
-      nonUserVotes.forEach(obj => {
-        const values = Object.values(obj);
-        if (userId) {
-          dispatch(handleVote(values[0], values[1], values[2], userId));
-        }
-      });
+    if (loggedIn) {
+      dispatch(updateProgressBar(true));
+
+      if (nonUserVotes.length) {
+        nonUserVotes.forEach(obj => {
+          const values = Object.values(obj);
+          if (userId) {
+            dispatch(handleVote(values[0], values[1], values[2], userId));
+          }
+        });
+      }
+      return dispatch(fetchGames()).then(() =>
+        dispatch(updateProgressBar(false))
+      );
     }
-    setVoteLocalStorageVariable();
-    dispatch(fetchGames());
+    const voteCount = checkVoteCount();
+    return dispatch(updateVotecount(voteCount));
   }
 
   handleFetchFeedback(game) {
@@ -93,11 +99,11 @@ const mapStateToProps = state => ({
   loggedIn: state.auth.currentUser !== null,
   games: state.games.battleGames,
   feedback: state.games.feedback,
-  count: state.games.sessionVoteCount,
+  count: state.onboard.voteCount,
   nonUserVotes: state.games.nonUserVotes,
   motivations: state.user.motivations,
   userId: checkIfUser(state),
-  loading: state.games.loading
+  loading: state.progressBar.loading
 });
 
 export default connect(mapStateToProps)(LandingPage);

--- a/client/src/components/onBoard/userOnboard.js
+++ b/client/src/components/onBoard/userOnboard.js
@@ -4,48 +4,42 @@ import { setNonUserVotes } from "../../actions/gameActions";
 import {
   nextTestRequest,
   nextTestSuccess,
-  setLoading
+  setLoading,
+  updateVoteCount
 } from "../../actions/onboarding";
 import OnboardPropmt from "./onboardPrompt";
 import Loading from "../loading";
-import {
-  setVoteLocalStorageVariable,
-  incrementVoteCount,
-  loadVoteCount
-} from "../../local-storage";
+import { incrementVoteCount } from "../../local-storage";
 
 export class UserOnboard extends React.Component {
   state = {
     loading: false
   };
 
-  count = Number(loadVoteCount());
-
-  state = {
-    imgLoaded: false
-  };
-
   componentDidMount() {
-    const { dispatch } = this.props;
-    setVoteLocalStorageVariable();
-    let myKey;
-    myKey = `test${this.count}`;
-    dispatch(nextTestSuccess(myKey));
+    const { count, dispatch } = this.props;
+    dispatch(nextTestSuccess(`test${count}`));
+  }
+
+  componentDidUpdate(prevProps) {
+    const { count, dispatch } = this.props;
+    if (count !== prevProps.count) {
+      dispatch(nextTestSuccess(`test${count}`));
+    }
   }
 
   handleVote = () => {
-    const { dispatch } = this.props;
-    let myKey;
-    this.count++;
-    incrementVoteCount();
-    myKey = `test${this.count}`;
+    const { count, dispatch } = this.props;
+    incrementVoteCount(count);
+    dispatch(updateVoteCount(count + 1));
+    const myKey = `test${count + 1}`;
     dispatch(nextTestRequest());
     dispatch(setLoading());
     dispatch(nextTestSuccess(myKey));
   };
 
   render() {
-    const { dispatch, tests } = this.props;
+    const { count, dispatch, tests } = this.props;
     const { loading } = this.state;
     let content;
     if (loading) {
@@ -55,7 +49,7 @@ export class UserOnboard extends React.Component {
         </div>
       );
     }
-    if (this.count < 13) {
+    if (count < 13) {
       content = (
         <>
           <div className="battle-container">
@@ -123,21 +117,22 @@ export class UserOnboard extends React.Component {
             <progress
               id="onboarding-progress"
               className="nes-progress is-primary"
-              value={this.count * 10}
+              value={count * 10}
               max="120"
             />
           </div>
         </>
       );
-    } else if (this.count >= 11) {
+    } else if (count >= 11) {
       content = <OnboardPropmt />;
     }
     return content;
   }
 }
 const mapStateToProps = state => ({
-  tests: state.onboard,
-  loading: state.onboard
+  count: state.onboard.voteCount,
+  loading: state.onboard.loading,
+  tests: state.onboard
 });
 
 export default connect(mapStateToProps)(UserOnboard);

--- a/client/src/components/onBoard/userOnboard.js
+++ b/client/src/components/onBoard/userOnboard.js
@@ -1,24 +1,18 @@
 import React from "react";
 import { connect } from "react-redux";
 import { setNonUserVotes } from "../../actions/gameActions";
-import {
-  nextTestRequest,
-  nextTestSuccess,
-  setLoading,
-  updateVoteCount
-} from "../../actions/onboarding";
+import { nextTestSuccess, updateVoteCount } from "../../actions/onboarding";
+import { updateProgressBar } from "../../actions/progressBar";
 import OnboardPropmt from "./onboardPrompt";
 import Loading from "../loading";
 import { incrementVoteCount } from "../../local-storage";
 
 export class UserOnboard extends React.Component {
-  state = {
-    loading: false
-  };
-
   componentDidMount() {
     const { count, dispatch } = this.props;
+    dispatch(updateProgressBar(true));
     dispatch(nextTestSuccess(`test${count}`));
+    dispatch(updateProgressBar(false));
   }
 
   componentDidUpdate(prevProps) {
@@ -30,17 +24,16 @@ export class UserOnboard extends React.Component {
 
   handleVote = () => {
     const { count, dispatch } = this.props;
+    dispatch(updateProgressBar(true));
     incrementVoteCount(count);
     dispatch(updateVoteCount(count + 1));
     const myKey = `test${count + 1}`;
-    dispatch(nextTestRequest());
-    dispatch(setLoading());
     dispatch(nextTestSuccess(myKey));
+    dispatch(updateProgressBar(false));
   };
 
   render() {
-    const { count, dispatch, tests } = this.props;
-    const { loading } = this.state;
+    const { count, dispatch, loading, tests } = this.props;
     let content;
     if (loading) {
       content = (
@@ -48,8 +41,7 @@ export class UserOnboard extends React.Component {
           <Loading />
         </div>
       );
-    }
-    if (count < 13) {
+    } else if (count < 13) {
       content = (
         <>
           <div className="battle-container">
@@ -131,7 +123,7 @@ export class UserOnboard extends React.Component {
 }
 const mapStateToProps = state => ({
   count: state.onboard.voteCount,
-  loading: state.onboard.loading,
+  loading: state.progressBar.loading,
   tests: state.onboard
 });
 

--- a/client/src/local-storage.js
+++ b/client/src/local-storage.js
@@ -40,16 +40,16 @@ export const saveVoteCount = count => {
   }
 };
 
-export const incrementVoteCount = () => {
-  let count = parseInt(loadVoteCount(), 10);
-  count += 1;
-  return saveVoteCount(count);
+export const incrementVoteCount = count => {
+  return saveVoteCount(count + 1);
 };
 
 export const setVoteLocalStorageVariable = () => {
-  if (!loadVoteCount()) {
+  const count = loadVoteCount();
+  if (!count) {
     return saveVoteCount(1);
   }
+  return count;
 };
 
 export const checkVoteCount = () => {

--- a/client/src/local-storage.js
+++ b/client/src/local-storage.js
@@ -53,9 +53,12 @@ export const setVoteLocalStorageVariable = () => {
 };
 
 export const checkVoteCount = () => {
-  if (Number(loadVoteCount()) === 0 || Number.isNaN(loadVoteCount)) {
-    saveVoteCount(1);
-  } else if (Number(loadVoteCount()) > 13) {
-    saveVoteCount(13);
+  let count = Number(loadVoteCount());
+  if (count === 0 || Number.isNaN(count)) {
+    count = 1;
+  } else if (count > 13) {
+    count = 13;
   }
+  saveVoteCount(count);
+  return count;
 };

--- a/client/src/reducers/onBoardingReducer.js
+++ b/client/src/reducers/onBoardingReducer.js
@@ -1,8 +1,6 @@
 import {
   CLEAR_LOADING,
   NEXT_TEST_SUCCESS,
-  NEXT_TEST_REQUEST,
-  SET_LOADING,
   UDPATE_VOTE_COUNT
 } from "../actions/onboarding";
 
@@ -32,7 +30,6 @@ import kotor2 from "../assets/onboard-pics/kotor2.jpg";
 import dao from "../assets/onboard-pics/dao.jpg";
 
 const initialState = {
-  loading: false,
   showing: [
     { name: "test", coverUrl: "test", id: "test" },
     { name: "test", coverUrl: "test", id: "test" }
@@ -189,18 +186,10 @@ export default function reducer(state = initialState, action) {
       return Object.assign({}, state, {
         loading: false
       });
-    case NEXT_TEST_REQUEST:
-      return Object.assign({}, state, {
-        loading: true
-      });
     case NEXT_TEST_SUCCESS:
       return Object.assign({}, state, {
         loading: false,
         showing: state[action.payload]
-      });
-    case SET_LOADING:
-      return Object.assign({}, state, {
-        loading: true
       });
     case UDPATE_VOTE_COUNT:
       return Object.assign({}, state, {

--- a/client/src/reducers/onBoardingReducer.js
+++ b/client/src/reducers/onBoardingReducer.js
@@ -181,7 +181,7 @@ const initialState = {
       id: "5c9bfef9054d8f2e1010f139"
     }
   ],
-  voteCount: 0
+  voteCount: 1
 };
 export default function reducer(state = initialState, action) {
   switch (action.type) {

--- a/client/src/reducers/onBoardingReducer.js
+++ b/client/src/reducers/onBoardingReducer.js
@@ -1,37 +1,42 @@
 import {
+  CLEAR_LOADING,
   NEXT_TEST_SUCCESS,
   NEXT_TEST_REQUEST,
   SET_LOADING,
-  CLEAR_LOADING
-} from '../actions/onboarding';
+  UDPATE_VOTE_COUNT
+} from "../actions/onboarding";
 
-import ssbm from '../assets/onboard-pics/ssbm.jpg';
-import re4 from '../assets/onboard-pics/re4.jpg';
-import halo from '../assets/onboard-pics/halo.jpg';
-import doom from '../assets/onboard-pics/doom.jpg';
-import lol from '../assets/onboard-pics/lol.jpg'
-import wow from '../assets/onboard-pics/wow.jpg';
-import csgo from '../assets/onboard-pics/csgo.jpg';
-import gw2 from '../assets/onboard-pics/gw2.jpg';
-import ds from '../assets/onboard-pics/ds.jpg';
-import sc2 from '../assets/onboard-pics/sc2.jpg';
-import sf2 from '../assets/onboard-pics/sf2.jpg';
-import aoe from '../assets/onboard-pics/aoe.jpg';
-import ff7 from '../assets/onboard-pics/ff7.jpg';
-import d2 from '../assets/onboard-pics/d2.jpg';
-import oot from '../assets/onboard-pics/oot.jpg';
-import dota2 from '../assets/onboard-pics/dota2.jpg';
-import tes5 from '../assets/onboard-pics/tes5.jpg';
-import animal from '../assets/onboard-pics/animal.jpg';
-import mgs3 from '../assets/onboard-pics/mgs3.jpg';
-import me2 from '../assets/onboard-pics/me2.jpg';
-import fnv from '../assets/onboard-pics/fnv.jpg';
-import kh2 from '../assets/onboard-pics/kh2.jpg';
-import kotor2 from '../assets/onboard-pics/kotor2.jpg';
-import dao from '../assets/onboard-pics/dao.jpg';
+import ssbm from "../assets/onboard-pics/ssbm.jpg";
+import re4 from "../assets/onboard-pics/re4.jpg";
+import halo from "../assets/onboard-pics/halo.jpg";
+import doom from "../assets/onboard-pics/doom.jpg";
+import lol from "../assets/onboard-pics/lol.jpg";
+import wow from "../assets/onboard-pics/wow.jpg";
+import csgo from "../assets/onboard-pics/csgo.jpg";
+import gw2 from "../assets/onboard-pics/gw2.jpg";
+import ds from "../assets/onboard-pics/ds.jpg";
+import sc2 from "../assets/onboard-pics/sc2.jpg";
+import sf2 from "../assets/onboard-pics/sf2.jpg";
+import aoe from "../assets/onboard-pics/aoe.jpg";
+import ff7 from "../assets/onboard-pics/ff7.jpg";
+import d2 from "../assets/onboard-pics/d2.jpg";
+import oot from "../assets/onboard-pics/oot.jpg";
+import dota2 from "../assets/onboard-pics/dota2.jpg";
+import tes5 from "../assets/onboard-pics/tes5.jpg";
+import animal from "../assets/onboard-pics/animal.jpg";
+import mgs3 from "../assets/onboard-pics/mgs3.jpg";
+import me2 from "../assets/onboard-pics/me2.jpg";
+import fnv from "../assets/onboard-pics/fnv.jpg";
+import kh2 from "../assets/onboard-pics/kh2.jpg";
+import kotor2 from "../assets/onboard-pics/kotor2.jpg";
+import dao from "../assets/onboard-pics/dao.jpg";
 
 const initialState = {
-  showing: [{ name: 'test', coverUrl: 'test', id: 'test' }, { name: 'test', coverUrl: 'test', id: 'test' }],
+  loading: false,
+  showing: [
+    { name: "test", coverUrl: "test", id: "test" },
+    { name: "test", coverUrl: "test", id: "test" }
+  ],
   test1: [
     {
       name: "Super Smash Bros. Melee",
@@ -42,7 +47,8 @@ const initialState = {
       name: "Halo: Combat Evolved",
       coverUrl: halo,
       id: "5c9a959ba5d0dd09e07f45a1"
-    }],
+    }
+  ],
   test2: [
     {
       name: "Resident Evil 4",
@@ -53,7 +59,8 @@ const initialState = {
       name: "DOOM",
       coverUrl: doom,
       id: "5c9bfce1054d8f2e1010f126"
-    }],
+    }
+  ],
   test3: [
     {
       name: "League of Legends",
@@ -64,7 +71,8 @@ const initialState = {
       name: "World of Warcraft",
       coverUrl: wow,
       id: "5ca2739a5ce0f90ebb413b03"
-    }],
+    }
+  ],
   test4: [
     {
       name: "Counter-Strike: Global Offensive",
@@ -75,7 +83,8 @@ const initialState = {
       name: "Guild Wars 2",
       coverUrl: gw2,
       id: "5ca388668b14bd0017521aeb"
-    }],
+    }
+  ],
   test5: [
     {
       name: "Dark Souls",
@@ -86,7 +95,8 @@ const initialState = {
       name: "StarCraft II: Wings of Liberty",
       coverUrl: sc2,
       id: "5c9bfb5d054d8f2e1010f118"
-    }],
+    }
+  ],
   test6: [
     {
       name: "Street Fighter II",
@@ -97,7 +107,8 @@ const initialState = {
       name: "Age of Empires II: The Age of Kings",
       id: "5c9bfe5d054d8f2e1010f133",
       coverUrl: aoe
-    }],
+    }
+  ],
   test7: [
     {
       name: "Final Fantasy VII",
@@ -108,7 +119,8 @@ const initialState = {
       name: "Diablo: II",
       coverUrl: d2,
       id: "5c9bfd5c054d8f2e1010f12a"
-    }],
+    }
+  ],
   test8: [
     {
       name: "The Legend of Zelda: Ocarina of Time",
@@ -119,7 +131,8 @@ const initialState = {
       name: "Dota 2",
       coverUrl: dota2,
       id: "5ca657431989fe0017440ee9"
-    }],
+    }
+  ],
   test9: [
     {
       name: "The Elder Scrolls V: Skyrim",
@@ -130,7 +143,8 @@ const initialState = {
       name: "Animal Crossing",
       coverUrl: animal,
       id: "5ca6580c1989fe0017440eef"
-    }],
+    }
+  ],
   test10: [
     {
       name: "Metal Gear Solid 3: Snake Eater",
@@ -141,7 +155,8 @@ const initialState = {
       name: "Mass Effect 2",
       coverUrl: me2,
       id: "5c9bf3801eaffb2ce28273fb"
-    }],
+    }
+  ],
   test11: [
     {
       name: "Fallout: New Vegas",
@@ -152,7 +167,8 @@ const initialState = {
       name: "Kingdom Hearts 2",
       coverUrl: kh2,
       id: "5c9bf853054d8f2e1010f106"
-    }],
+    }
+  ],
   test12: [
     {
       name: "Star Wars: Knights of the Old Republic II - The Sith Lords",
@@ -165,33 +181,32 @@ const initialState = {
       id: "5c9bfef9054d8f2e1010f139"
     }
   ],
-  loading: false
-}
+  voteCount: 0
+};
 export default function reducer(state = initialState, action) {
-  if (action.type === NEXT_TEST_SUCCESS) {
-    let next;
-    next = action.payload
-    return Object.assign({}, state, {
-      loading: false,
-      showing: state[next]
-    })
+  switch (action.type) {
+    case CLEAR_LOADING:
+      return Object.assign({}, state, {
+        loading: false
+      });
+    case NEXT_TEST_REQUEST:
+      return Object.assign({}, state, {
+        loading: true
+      });
+    case NEXT_TEST_SUCCESS:
+      return Object.assign({}, state, {
+        loading: false,
+        showing: state[action.payload]
+      });
+    case SET_LOADING:
+      return Object.assign({}, state, {
+        loading: true
+      });
+    case UDPATE_VOTE_COUNT:
+      return Object.assign({}, state, {
+        voteCount: action.count
+      });
+    default:
+      return state;
   }
-  else if (action.type === NEXT_TEST_REQUEST) {
-    return Object.assign({}, state, {
-      loading: true
-    })
-  }
-
-  else if (action.type === CLEAR_LOADING) {
-    return Object.assign({}, state, {
-      loading: false
-    })
-  }
-
-  else if (action.type === SET_LOADING) {
-    return Object.assign({}, state, {
-      loading: true
-    })
-  }
-  return state;
 }

--- a/client/src/reducers/progressBar.js
+++ b/client/src/reducers/progressBar.js
@@ -1,0 +1,14 @@
+import { UPDATE_PROGRESS_BAR } from "../actions/progressBar";
+
+const initialState = { loading: false };
+
+export default function reducer(state = initialState, action) {
+  switch (action.type) {
+    case UPDATE_PROGRESS_BAR:
+      return Object.assign({}, state, {
+        loading: action.loading
+      });
+    default:
+      return state;
+  }
+}

--- a/client/src/store.js
+++ b/client/src/store.js
@@ -3,22 +3,25 @@ import { reducer as formReducer } from "redux-form";
 import thunk from "redux-thunk";
 import { loadAuthToken } from "./local-storage";
 import allGamesReducer from "./reducers/allGamesReducer";
-import onBoardingReducer from "./reducers/onBoardingReducer";
 import authReducer from "./reducers/auth";
+import onBoardingReducer from "./reducers/onBoardingReducer";
 import gamesReducer from "./reducers/gameReducer";
+import progressBarReducer from "./reducers/progressBar";
 import userReducer from "./reducers/userReducer";
 import windowReducer from "./reducers/window";
 
 import { setAuthToken, refreshAuthToken } from "./actions/auth";
 
+// eslint-disable-next-line no-underscore-dangle
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(
   combineReducers({
-    form: formReducer,
     auth: authReducer,
+    form: formReducer,
     games: gamesReducer,
     allGames: allGamesReducer,
+    progressBar: progressBarReducer,
     user: userReducer,
     window: windowReducer,
     onboard: onBoardingReducer


### PR DESCRIPTION
Updated the landing page so it only fetches games if the user is logged in. This should improve initial load times for people visiting the site for the first time. Also moved the onboarding vote count to the Redux store and cleaned up some loading screen logic.