### PR TITLE
Bumps mongoose to 5.7.5 or later

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -27,7 +27,7 @@
     "jsonwebtoken": "^8.5.1",
     "knex": "^0.19.5",
     "moment": "^2.24.0",
-    "mongoose": "^5.5.2",
+    "mongoose": ">=5.7.5",
     "morgan": "^1.9.1",
     "nodemon": "^1.18.11",
     "passport": "^0.4.0",


### PR DESCRIPTION
Just bumps up the version of mongoose to avoid a security vulnerability.